### PR TITLE
Add retryEAGAIN callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The options are:
     true sonic-boom will retry the operation, otherwise it will bubble the
     error. `err` is the error that caused this function to be called,
     `writeBufferLen` is the length of the buffer sonic-boom tried to write, and
-    `remainingBufferLen` is the lenght of the remaining buffer sonic-boom didn't try to write.
+    `remainingBufferLen` is the length of the remaining buffer sonic-boom didn't try to write.
 
 For `sync:false`  a `SonicBoom` instance will emit the `'ready'` event when a file descriptor is available.
 For `sync:true` this is not relevant because the `'ready'` event will be fired when the `SonicBoom` instance is created, before it can be subscribed to.

--- a/README.md
+++ b/README.md
@@ -63,10 +63,16 @@ The options are:
 * `sync`: perform writes synchronously (similar to `console.log`).
 * `append`: appends writes to dest file instead of truncating it (default `true`).
 * `mkdir`: ensure directory for dest file exists when `true` (default `false`).
+* `retryEAGAIN(err, writeBufferLen, remainingBufferLen)`: a function that will be called when sonic-boom
+    write/writeSync/flushSync encounters a EAGAIN error. If the return value is
+    true sonic-boom will retry the operation, otherwise it will bubble the
+    error. `err` is the error that caused this function to be called,
+    `writeBufferLen` is the length of the buffer sonic-boom tried to write, and
+    `remainingBufferLen` is the lenght of the remaining buffer sonic-boom didn't try to write.
 
-For `sync:false`  a `SonicBoom` instance will emit the `'ready'` event when a file descriptor is available. 
-For `sync:true` this is not relevant because the `'ready'` event will be fired when the `SonicBoom` instance is created, before it can be subscribed to. 
-   
+For `sync:false`  a `SonicBoom` instance will emit the `'ready'` event when a file descriptor is available.
+For `sync:true` this is not relevant because the `'ready'` event will be fired when the `SonicBoom` instance is created, before it can be subscribed to.
+
 
 ### SonicBoom#write(string)
 

--- a/index.js
+++ b/index.js
@@ -108,7 +108,6 @@ function SonicBoom (opts) {
   this.append = append || false
   this.retryEAGAIN = retryEAGAIN || (() => true)
   this.mkdir = mkdir || false
-  this._againTimeout = null
 
   if (typeof fd === 'number') {
     this.fd = fd
@@ -124,7 +123,7 @@ function SonicBoom (opts) {
 
   this.release = (err, n) => {
     if (err) {
-      if (err.code === 'EAGAIN' && this.retryEAGAIN(err, this._writingBuf.length, this._buf.length)) {
+      if (err.code === 'EAGAIN' && this.retryEAGAIN(err, this._writingBuf.length, this._len - this._writingBuf.length)) {
         if (this.sync) {
           // This error code should not happen in sync mode, because it is
           // not using the underlining operating system asynchronous functions.
@@ -138,8 +137,7 @@ function SonicBoom (opts) {
           }
         } else {
           // Let's give the destination some time to process the chunk.
-          this._againTimeout = setTimeout(() => {
-            this._againTimeout = null
+          setTimeout(() => {
             fs.write(this.fd, this._writingBuf, 'utf8', this.release)
           }, BUSY_WRITE_TIMEOUT)
         }
@@ -334,18 +332,18 @@ SonicBoom.prototype.flushSync = function () {
     throw new Error('sonic boom is not ready yet')
   }
 
-  if (this._againTimeout) {
-    this._againTimeout = null
+  if (!this._writing && this._writingBuf.length > 0) {
     this._bufs.unshift(this._writingBuf)
     this._writingBuf = ''
   }
 
   while (this._bufs.length) {
+    const buf = this._bufs[0]
     try {
-      this._len -= fs.writeSync(this.fd, this._bufs[0], 'utf8')
+      this._len -= fs.writeSync(this.fd, buf, 'utf8')
       this._bufs.shift()
     } catch (err) {
-      if (err.code !== 'EAGAIN' || !this.retryEAGAIN(err, this._buf.length, 0)) {
+      if (err.code !== 'EAGAIN' || !this.retryEAGAIN(err, buf.length, this._len - buf.length)) {
         throw err
       }
 

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ const path = require('path')
 const proxyquire = require('proxyquire')
 const SonicBoom = require('.')
 
+const MAX_WRITE = 16 * 1024 * 1024
 const files = []
 let count = 0
 
@@ -965,24 +966,13 @@ test('throw error in flushSync on EAGAIN', (t) => {
   })
 })
 
-test('retryEAGAIN receives remaining buffer if exceeds MAX_WRITE', (t) => {
-  t.plan(11)
+test('retryEAGAIN receives remaining buffer on async if write fails', (t) => {
+  t.plan(12)
 
   const fakeFs = Object.create(fs)
-  fakeFs.write = function (fd, buf, enc, cb) {
-    t.pass('fake fs.write called')
-    fakeFs.write = fs.write
-    const err = new Error('EAGAIN')
-    err.code = 'EAGAIN'
-    process.nextTick(cb, err)
-  }
   const SonicBoom = proxyquire('.', {
     fs: fakeFs
   })
-
-  const MAX_WRITE = 16 * 1024 * 1024
-  const remaining = 42
-  const buf = Buffer.alloc(MAX_WRITE + remaining).fill('x').toString()
 
   const dest = file()
   const fd = fs.openSync(dest, 'w')
@@ -992,8 +982,8 @@ test('retryEAGAIN receives remaining buffer if exceeds MAX_WRITE', (t) => {
     minLength: 12,
     retryEAGAIN: (err, writeBufferLen, remainingBufferLen) => {
       t.equal(err.code, 'EAGAIN')
-      t.equal(writeBufferLen, MAX_WRITE)
-      t.equal(remainingBufferLen, remaining)
+      t.equal(writeBufferLen, 12)
+      t.equal(remainingBufferLen, 11)
       return false
     }
   })
@@ -1004,17 +994,95 @@ test('retryEAGAIN receives remaining buffer if exceeds MAX_WRITE', (t) => {
 
   stream.once('error', err => {
     t.equal(err.code, 'EAGAIN')
-    t.notOk(stream.write('done'))
+    t.ok(stream.write('done'))
   })
 
-  t.notOk(stream.write(buf))
+  fakeFs.write = function (fd, buf, enc, cb) {
+    t.pass('fake fs.write called')
+    fakeFs.write = fs.write
+    const err = new Error('EAGAIN')
+    err.code = 'EAGAIN'
+    t.ok(stream.write('sonic boom\n'))
+    process.nextTick(cb, err)
+  }
+
+  t.ok(stream.write('hello world\n'))
 
   stream.end()
 
   stream.on('finish', () => {
     fs.readFile(dest, 'utf8', (err, data) => {
       t.error(err)
-      t.equal(data.slice(MAX_WRITE + remaining), 'done')
+      t.equal(data, 'hello world\nsonic boom\ndone')
+    })
+  })
+  stream.on('close', () => {
+    t.pass('close emitted')
+  })
+})
+
+test('retryEAGAIN receives remaining buffer if exceeds MAX_WRITE', (t) => {
+  t.plan(17)
+
+  const fakeFs = Object.create(fs)
+  const SonicBoom = proxyquire('.', {
+    fs: fakeFs
+  })
+
+  const dest = file()
+  const fd = fs.openSync(dest, 'w')
+  const buf = Buffer.alloc(MAX_WRITE - 2).fill('x').toString() // 1 MB
+  const stream = new SonicBoom({
+    fd,
+    sync: false,
+    minLength: MAX_WRITE - 1,
+    retryEAGAIN: (err, writeBufferLen, remainingBufferLen) => {
+      t.equal(err.code, 'EAGAIN', 'retryEAGAIN received EAGAIN error')
+      t.equal(writeBufferLen, buf.length, 'writeBufferLen === buf.length')
+      t.equal(remainingBufferLen, 23, 'remainingBufferLen === 23')
+      return false
+    }
+  })
+
+  stream.on('ready', () => {
+    t.pass('ready emitted')
+  })
+
+  fakeFs.write = function (fd, buf, enc, cb) {
+    t.pass('fake fs.write called')
+    const err = new Error('EAGAIN')
+    err.code = 'EAGAIN'
+    process.nextTick(cb, err)
+  }
+
+  fakeFs.writeSync = function (fd, buf, enc, cb) {
+    t.pass('fake fs.write called')
+    const err = new Error('EAGAIN')
+    err.code = 'EAGAIN'
+    throw err
+  }
+
+  t.ok(stream.write(buf), 'write buf')
+  t.notOk(stream.write('hello world\nsonic boom\n'), 'write hello world sonic boom')
+
+  stream.once('error', err => {
+    t.equal(err.code, 'EAGAIN', 'bubbled error should be EAGAIN')
+
+    try {
+      stream.flushSync()
+    } catch (err) {
+      t.equal(err.code, 'EAGAIN', 'thrown error should be EAGAIN')
+      fakeFs.write = fs.write
+      fakeFs.writeSync = fs.writeSync
+      stream.end()
+    }
+  })
+
+  stream.on('finish', () => {
+    t.pass('finish emitted')
+    fs.readFile(dest, 'utf8', (err, data) => {
+      t.error(err)
+      t.equal(data, `${buf}hello world\nsonic boom\n`, 'data on file should match written')
     })
   })
   stream.on('close', () => {
@@ -1281,7 +1349,7 @@ test('should throw if minLength >= MAX_WRITE', (t) => {
 
     new SonicBoom({
       fd,
-      minLength: 16 * 1024 * 1024
+      minLength: MAX_WRITE
     })
   })
 })


### PR DESCRIPTION
Add a synchronous callback for when we encounter EAGAIN errors. The
function must return `true` or `false` to inform sonic-boom if it should
continue retrying or if it should bubble up the error it encounters.

Fixes: https://github.com/pinojs/sonic-boom/issues/65

---

The implementation here is different than the ones discussed in the issue. Adding a maxEAGAIN/maxFlushRetries prove challeging because of `SonicBoom.release` (hard to keep track of attempts with `SonicBoom.release` and a mix of `fs.write` and `fs.writeSync` in the code). This alternative approach gives control to the user to decide if it should retry or not. With this, flushSync will throw if retryEAGAIN returns false. I'm open to discuss other approaches but wanted to have something as a starting point first.