### PR TITLE
feat: introduce write event

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,37 @@ Closes the stream, the data will be flushed down asynchronously
 
 Closes the stream immediately, the data is not flushed.
 
+### Events
+
+
+#### SonicBoom#close
+
+See [Stream#close](https://nodejs.org/api/stream.html#event-close). The `'close'` event when the instance has been closed.
+
+#### SonicBoom#drain
+
+See [Stream#drain](https://nodejs.org/api/stream.html#event-drain). The `'drain'` event is emitted when source can resume sending data.
+
+#### SonicBoom#drop <any>
+
+When destination file maximal length is reached, the `'drop'` event is emitted with data that could not be written. 
+
+#### SonicBoom#error <Error>
+
+The `'error'` event is emitted when the destination file can not be opened, or written.
+
+#### SonicBoom#finish
+
+See [Stream#finish](https://nodejs.org/api/stream.html#event-finish). The `'finish'` event after calling `end()` method and when all data was written.
+
+#### SonicBoom#ready
+
+The `'ready'` event occurs when the created instance is ready to process input.
+
+#### SonicBoom#write <number>
+
+The `'write'` event occurs every time data is written to the underlying file. It emits the number of written bytes.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -149,6 +149,7 @@ function SonicBoom (opts) {
       }
       return
     }
+    this.emit('write', n)
 
     this._len -= n
     this._writingBuf = this._writingBuf.slice(n)

--- a/test.js
+++ b/test.js
@@ -776,6 +776,38 @@ function buildTests (test, sync) {
       })
     })
   })
+
+  test('emit write events', (t) => {
+    t.plan(7)
+
+    const dest = file()
+    const stream = new SonicBoom({ dest, sync })
+
+    stream.on('ready', () => {
+      t.pass('ready emitted')
+    })
+
+    let length = 0
+    stream.on('write', (bytes) => {
+      length += bytes
+    })
+
+    t.ok(stream.write('hello world\n'))
+    t.ok(stream.write('something else\n'))
+
+    stream.end()
+
+    stream.on('finish', () => {
+      fs.readFile(dest, 'utf8', (err, data) => {
+        t.error(err)
+        t.equal(data, 'hello world\nsomething else\n')
+        t.equal(length, 27)
+      })
+    })
+    stream.on('close', () => {
+      t.pass('close emitted')
+    })
+  })
 }
 
 test('drain deadlock', (t) => {


### PR DESCRIPTION
### What's in there?

Hi Pino community!

In order to implement log rotation based on SonicBoom (original [issue](https://github.com/pinojs/pino/issues/1323), I would need a way to track bytes written to the underlying file.

Here is [the PR](https://github.com/feugy/pino-roll/pull/3#discussion_r843753896) for implementing a file rotation transport that can roll either on time or size.

The `write` event exposes this information without compromising performance.