### PR TITLE
chore(package): remove husky object

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,6 @@
   "dependencies": {
     "atomic-sleep": "^1.0.0"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm test"
-    }
-  },
   "tsd": {
     "directory": "./types"
   }


### PR DESCRIPTION
Hooks migrated to `.husky` directory in Husky v6