### PR TITLE
Don't add test and development files to package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,12 @@
 tsconfig.json
 types/index.test-d.ts
 .nyc_output
+.husky
+fixtures
+.eslintignore
+.taprc
+bench.js
+check.js
+example.js
+test.js
+types/tests


### PR DESCRIPTION
This PR removes development files and test files from the NPM package.

If it is preferred to keep the test files, I'll update the PR.