### PR TITLE
.write(Buffer) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       matrix:
         node-version: [14, 16, 18]
         os: [macos-latest, ubuntu-latest, windows-latest]
+        exclude:
+          - os: windows-latest
+            node-version: 14
     steps:
       - name: Check out repo
         uses: actions/checkout@v3

--- a/bench.js
+++ b/bench.js
@@ -11,6 +11,10 @@ const sonic = new SonicBoom({ fd })
 const sonic4k = new SonicBoom({ fd, minLength: 4096 })
 const sonicSync = new SonicBoom({ fd, sync: true })
 const sonicSync4k = new SonicBoom({ fd, minLength: 4096, sync: true })
+const sonicBuffer = new SonicBoom({ fd, contentMode: 'buffer' })
+const sonic4kBuffer = new SonicBoom({ fd, contentMode: 'buffer', minLength: 4096 })
+const sonicSyncBuffer = new SonicBoom({ fd, contentMode: 'buffer', sync: true })
+const sonicSync4kBuffer = new SonicBoom({ fd, contentMode: 'buffer', minLength: 4096, sync: true })
 const dummyConsole = new Console(fs.createWriteStream('/dev/null'))
 
 const MAX = 10000
@@ -58,27 +62,27 @@ const run = bench([
     setImmediate(cb)
   },
   function benchSonicBuf (cb) {
-    sonic.once('drain', cb)
+    sonicBuffer.once('drain', cb)
     for (let i = 0; i < MAX; i++) {
-      sonic.write(buf)
+      sonicBuffer.write(buf)
     }
   },
   function benchSonicSyncBuf (cb) {
-    sonicSync.once('drain', cb)
+    sonicSyncBuffer.once('drain', cb)
     for (let i = 0; i < MAX; i++) {
-      sonicSync.write(buf)
+      sonicSyncBuffer.write(buf)
     }
   },
   function benchSonic4kBuf (cb) {
-    sonic4k.once('drain', cb)
+    sonic4kBuffer.once('drain', cb)
     for (let i = 0; i < MAX; i++) {
-      sonic4k.write(buf)
+      sonic4kBuffer.write(buf)
     }
   },
   function benchSonicSync4kBuf (cb) {
-    sonicSync4k.once('drain', cb)
+    sonicSync4kBuffer.once('drain', cb)
     for (let i = 0; i < MAX; i++) {
-      sonicSync4k.write(buf)
+      sonicSync4kBuffer.write(buf)
     }
   },
   function benchCoreBuf (cb) {

--- a/bench.js
+++ b/bench.js
@@ -15,11 +15,8 @@ const dummyConsole = new Console(fs.createWriteStream('/dev/null'))
 
 const MAX = 10000
 
-let str = ''
-
-for (let i = 0; i < 10; i++) {
-  str += 'hello'
-}
+const buf = Buffer.alloc(50, 'hello', 'utf8')
+const str = buf.toString()
 
 setTimeout(doBench, 100)
 
@@ -59,6 +56,36 @@ const run = bench([
       dummyConsole.log(str)
     }
     setImmediate(cb)
+  },
+  function benchSonicBuf (cb) {
+    sonic.once('drain', cb)
+    for (let i = 0; i < MAX; i++) {
+      sonic.write(buf)
+    }
+  },
+  function benchSonicSyncBuf (cb) {
+    sonicSync.once('drain', cb)
+    for (let i = 0; i < MAX; i++) {
+      sonicSync.write(buf)
+    }
+  },
+  function benchSonic4kBuf (cb) {
+    sonic4k.once('drain', cb)
+    for (let i = 0; i < MAX; i++) {
+      sonic4k.write(buf)
+    }
+  },
+  function benchSonicSync4kBuf (cb) {
+    sonicSync4k.once('drain', cb)
+    for (let i = 0; i < MAX; i++) {
+      sonicSync4k.write(buf)
+    }
+  },
+  function benchCoreBuf (cb) {
+    core.once('drain', cb)
+    for (let i = 0; i < MAX; i++) {
+      core.write(buf)
+    }
   }
 ], 1000)
 

--- a/index.js
+++ b/index.js
@@ -295,6 +295,7 @@ SonicBoom.prototype.flush = function () {
 
   if (this._bufs.length === 0) {
     this._bufs.push([])
+    this._lens.push(0)
   }
 
   actualWrite(this)
@@ -394,6 +395,7 @@ SonicBoom.prototype.flushSync = function () {
       this._len = Math.max(this._len - n, 0)
       if (buf.length <= 0) {
         this._bufs.shift()
+        this._lens.shift()
       }
     } catch (err) {
       const shouldRetry = err.code === 'EAGAIN' || err.code === 'EBUSY'
@@ -438,6 +440,7 @@ function actualClose (sonic) {
 
   sonic.destroyed = true
   sonic._bufs = []
+  sonic._lens = []
 
   if (sonic.fd !== 1 && sonic.fd !== 2) {
     fs.close(sonic.fd, done)

--- a/test/retry.test.js
+++ b/test/retry.test.js
@@ -16,12 +16,12 @@ function buildTests (test, sync) {
     t.plan(7)
 
     const fakeFs = Object.create(fs)
-    fakeFs.write = function (fd, buf, cb) {
+    fakeFs.write = function (fd, buf, ...args) {
       t.pass('fake fs.write called')
       fakeFs.write = fs.write
       const err = new Error('EAGAIN')
       err.code = 'EAGAIN'
-      process.nextTick(cb, err)
+      process.nextTick(args.pop(), err)
     }
     const SonicBoom = proxyquire('../', {
       fs: fakeFs
@@ -56,12 +56,12 @@ test('emit error on async EAGAIN', (t) => {
   t.plan(11)
 
   const fakeFs = Object.create(fs)
-  fakeFs.write = function (fd, buf, cb) {
+  fakeFs.write = function (fd, buf, ...args) {
     t.pass('fake fs.write called')
     fakeFs.write = fs.write
     const err = new Error('EAGAIN')
     err.code = 'EAGAIN'
-    process.nextTick(cb, err)
+    process.nextTick(args[args.length - 1], err)
   }
   const SonicBoom = proxyquire('../', {
     fs: fakeFs
@@ -109,7 +109,7 @@ test('retry on EAGAIN (sync)', (t) => {
   t.plan(7)
 
   const fakeFs = Object.create(fs)
-  fakeFs.writeSync = function (fd, buf, cb) {
+  fakeFs.writeSync = function (fd, buf, enc) {
     t.pass('fake fs.writeSync called')
     fakeFs.writeSync = fs.writeSync
     const err = new Error('EAGAIN')
@@ -148,7 +148,7 @@ test('emit error on EAGAIN (sync)', (t) => {
   t.plan(11)
 
   const fakeFs = Object.create(fs)
-  fakeFs.writeSync = function (fd, buf, cb) {
+  fakeFs.writeSync = function (fd, buf, enc) {
     t.pass('fake fs.writeSync called')
     fakeFs.writeSync = fs.writeSync
     const err = new Error('EAGAIN')
@@ -228,13 +228,13 @@ test('retryEAGAIN receives remaining buffer on async if write fails', (t) => {
     t.ok(stream.write('done'))
   })
 
-  fakeFs.write = function (fd, buf, cb) {
+  fakeFs.write = function (fd, buf, ...args) {
     t.pass('fake fs.write called')
     fakeFs.write = fs.write
     const err = new Error('EAGAIN')
     err.code = 'EAGAIN'
     t.ok(stream.write('sonic boom\n'))
-    process.nextTick(cb, err)
+    process.nextTick(args[args.length - 1], err)
   }
 
   t.ok(stream.write('hello world\n'))
@@ -279,14 +279,14 @@ test('retryEAGAIN receives remaining buffer if exceeds maxWrite', (t) => {
     t.pass('ready emitted')
   })
 
-  fakeFs.write = function (fd, buf, cb) {
+  fakeFs.write = function (fd, buf, ...args) {
     t.pass('fake fs.write called')
     const err = new Error('EAGAIN')
     err.code = 'EAGAIN'
-    process.nextTick(cb, err)
+    process.nextTick(args.pop(), err)
   }
 
-  fakeFs.writeSync = function (fd, buf, cb) {
+  fakeFs.writeSync = function (fd, buf, enc) {
     t.pass('fake fs.write called')
     const err = new Error('EAGAIN')
     err.code = 'EAGAIN'
@@ -325,12 +325,12 @@ test('retry on EBUSY', (t) => {
   t.plan(7)
 
   const fakeFs = Object.create(fs)
-  fakeFs.write = function (fd, buf, cb) {
+  fakeFs.write = function (fd, buf, ...args) {
     t.pass('fake fs.write called')
     fakeFs.write = fs.write
     const err = new Error('EBUSY')
     err.code = 'EBUSY'
-    process.nextTick(cb, err)
+    process.nextTick(args.pop(), err)
   }
   const SonicBoom = proxyquire('..', {
     fs: fakeFs
@@ -364,12 +364,12 @@ test('emit error on async EBUSY', (t) => {
   t.plan(11)
 
   const fakeFs = Object.create(fs)
-  fakeFs.write = function (fd, buf, cb) {
+  fakeFs.write = function (fd, buf, ...args) {
     t.pass('fake fs.write called')
     fakeFs.write = fs.write
     const err = new Error('EBUSY')
     err.code = 'EBUSY'
-    process.nextTick(cb, err)
+    process.nextTick(args.pop(), err)
   }
   const SonicBoom = proxyquire('..', {
     fs: fakeFs

--- a/test/retry.test.js
+++ b/test/retry.test.js
@@ -16,7 +16,7 @@ function buildTests (test, sync) {
     t.plan(7)
 
     const fakeFs = Object.create(fs)
-    fakeFs.write = function (fd, buf, enc, cb) {
+    fakeFs.write = function (fd, buf, cb) {
       t.pass('fake fs.write called')
       fakeFs.write = fs.write
       const err = new Error('EAGAIN')
@@ -56,7 +56,7 @@ test('emit error on async EAGAIN', (t) => {
   t.plan(11)
 
   const fakeFs = Object.create(fs)
-  fakeFs.write = function (fd, buf, enc, cb) {
+  fakeFs.write = function (fd, buf, cb) {
     t.pass('fake fs.write called')
     fakeFs.write = fs.write
     const err = new Error('EAGAIN')
@@ -109,7 +109,7 @@ test('retry on EAGAIN (sync)', (t) => {
   t.plan(7)
 
   const fakeFs = Object.create(fs)
-  fakeFs.writeSync = function (fd, buf, enc, cb) {
+  fakeFs.writeSync = function (fd, buf, cb) {
     t.pass('fake fs.writeSync called')
     fakeFs.writeSync = fs.writeSync
     const err = new Error('EAGAIN')
@@ -148,7 +148,7 @@ test('emit error on EAGAIN (sync)', (t) => {
   t.plan(11)
 
   const fakeFs = Object.create(fs)
-  fakeFs.writeSync = function (fd, buf, enc, cb) {
+  fakeFs.writeSync = function (fd, buf, cb) {
     t.pass('fake fs.writeSync called')
     fakeFs.writeSync = fs.writeSync
     const err = new Error('EAGAIN')
@@ -228,7 +228,7 @@ test('retryEAGAIN receives remaining buffer on async if write fails', (t) => {
     t.ok(stream.write('done'))
   })
 
-  fakeFs.write = function (fd, buf, enc, cb) {
+  fakeFs.write = function (fd, buf, cb) {
     t.pass('fake fs.write called')
     fakeFs.write = fs.write
     const err = new Error('EAGAIN')
@@ -279,14 +279,14 @@ test('retryEAGAIN receives remaining buffer if exceeds maxWrite', (t) => {
     t.pass('ready emitted')
   })
 
-  fakeFs.write = function (fd, buf, enc, cb) {
+  fakeFs.write = function (fd, buf, cb) {
     t.pass('fake fs.write called')
     const err = new Error('EAGAIN')
     err.code = 'EAGAIN'
     process.nextTick(cb, err)
   }
 
-  fakeFs.writeSync = function (fd, buf, enc, cb) {
+  fakeFs.writeSync = function (fd, buf, cb) {
     t.pass('fake fs.write called')
     const err = new Error('EAGAIN')
     err.code = 'EAGAIN'
@@ -325,7 +325,7 @@ test('retry on EBUSY', (t) => {
   t.plan(7)
 
   const fakeFs = Object.create(fs)
-  fakeFs.write = function (fd, buf, enc, cb) {
+  fakeFs.write = function (fd, buf, cb) {
     t.pass('fake fs.write called')
     fakeFs.write = fs.write
     const err = new Error('EBUSY')
@@ -364,7 +364,7 @@ test('emit error on async EBUSY', (t) => {
   t.plan(11)
 
   const fakeFs = Object.create(fs)
-  fakeFs.write = function (fd, buf, enc, cb) {
+  fakeFs.write = function (fd, buf, cb) {
     t.pass('fake fs.write called')
     fakeFs.write = fs.write
     const err = new Error('EBUSY')

--- a/test/write.test.js
+++ b/test/write.test.js
@@ -181,12 +181,12 @@ function buildTests (test, sync) {
     })
 
     if (sync) {
-      fakeFs.writeSync = function (fd, buf, enc) {
+      fakeFs.writeSync = function (fd, buf) {
         t.pass('fake fs.writeSync called')
         throw new Error('recoverable error')
       }
     } else {
-      fakeFs.write = function (fd, buf, enc, cb) {
+      fakeFs.write = function (fd, buf, cb) {
         t.pass('fake fs.write called')
         setTimeout(() => cb(new Error('recoverable error')), 0)
       }
@@ -253,11 +253,11 @@ test('write buffers that are not totally written', (t) => {
   t.plan(9)
 
   const fakeFs = Object.create(fs)
-  fakeFs.write = function (fd, buf, enc, cb) {
+  fakeFs.write = function (fd, buf, cb) {
     t.pass('fake fs.write called')
-    fakeFs.write = function (fd, buf, enc, cb) {
+    fakeFs.write = function (fd, buf, cb) {
       t.pass('calling real fs.write, ' + buf)
-      fs.write(fd, buf, enc, cb)
+      fs.write(fd, buf, cb)
     }
     process.nextTick(cb, null, 0)
   }
@@ -336,7 +336,7 @@ test('write enormously large buffers async atomicly', (t) => {
 
   const buf = Buffer.alloc(1023).fill('x').toString()
 
-  fakeFs.write = function (fd, _buf, enc, cb) {
+  fakeFs.write = function (fd, _buf, cb) {
     if (_buf.length % buf.length !== 0) {
       t.fail('write called with wrong buffer size')
     }
@@ -375,7 +375,7 @@ test('write should not drop new data if buffer is not full', (t) => {
 
   const buf = Buffer.alloc(100).fill('x').toString()
 
-  fakeFs.write = function (fd, _buf, enc, cb) {
+  fakeFs.write = function (fd, _buf, cb) {
     t.equal(_buf.length, buf.length + 2)
     setImmediate(cb, null, _buf.length)
     fakeFs.write = () => t.error('shouldnt call write again')
@@ -407,7 +407,7 @@ test('write should drop new data if buffer is full', (t) => {
 
   const buf = Buffer.alloc(100).fill('x').toString()
 
-  fakeFs.write = function (fd, _buf, enc, cb) {
+  fakeFs.write = function (fd, _buf, cb) {
     t.equal(_buf.length, buf.length)
     setImmediate(cb, null, _buf.length)
     fakeFs.write = () => t.error('shouldnt call write more than once')

--- a/test/write.test.js
+++ b/test/write.test.js
@@ -181,14 +181,14 @@ function buildTests (test, sync) {
     })
 
     if (sync) {
-      fakeFs.writeSync = function (fd, buf) {
+      fakeFs.writeSync = function (fd, buf, enc) {
         t.pass('fake fs.writeSync called')
         throw new Error('recoverable error')
       }
     } else {
-      fakeFs.write = function (fd, buf, cb) {
+      fakeFs.write = function (fd, buf, ...args) {
         t.pass('fake fs.write called')
-        setTimeout(() => cb(new Error('recoverable error')), 0)
+        setTimeout(() => args.pop()(new Error('recoverable error')), 0)
       }
     }
 
@@ -253,13 +253,13 @@ test('write buffers that are not totally written', (t) => {
   t.plan(9)
 
   const fakeFs = Object.create(fs)
-  fakeFs.write = function (fd, buf, cb) {
+  fakeFs.write = function (fd, buf, ...args) {
     t.pass('fake fs.write called')
-    fakeFs.write = function (fd, buf, cb) {
+    fakeFs.write = function (fd, buf, ...args) {
       t.pass('calling real fs.write, ' + buf)
-      fs.write(fd, buf, cb)
+      fs.write(fd, buf, ...args)
     }
-    process.nextTick(cb, null, 0)
+    process.nextTick(args[args.length - 1], null, 0)
   }
   const SonicBoom = proxyquire('../', {
     fs: fakeFs
@@ -336,12 +336,12 @@ test('write enormously large buffers async atomicly', (t) => {
 
   const buf = Buffer.alloc(1023).fill('x').toString()
 
-  fakeFs.write = function (fd, _buf, cb) {
+  fakeFs.write = function (fd, _buf, ...args) {
     if (_buf.length % buf.length !== 0) {
       t.fail('write called with wrong buffer size')
     }
 
-    setImmediate(cb, null, _buf.length)
+    setImmediate(args[args.length - 1], null, _buf.length)
   }
 
   for (let i = 0; i < 1024 * 512; i++) {
@@ -375,9 +375,9 @@ test('write should not drop new data if buffer is not full', (t) => {
 
   const buf = Buffer.alloc(100).fill('x').toString()
 
-  fakeFs.write = function (fd, _buf, cb) {
+  fakeFs.write = function (fd, _buf, ...args) {
     t.equal(_buf.length, buf.length + 2)
-    setImmediate(cb, null, _buf.length)
+    setImmediate(args[args.length - 1], null, _buf.length)
     fakeFs.write = () => t.error('shouldnt call write again')
     stream.end()
   }
@@ -407,9 +407,9 @@ test('write should drop new data if buffer is full', (t) => {
 
   const buf = Buffer.alloc(100).fill('x').toString()
 
-  fakeFs.write = function (fd, _buf, cb) {
+  fakeFs.write = function (fd, _buf, ...args) {
     t.equal(_buf.length, buf.length)
-    setImmediate(cb, null, _buf.length)
+    setImmediate(args[args.length - 1], null, _buf.length)
     fakeFs.write = () => t.error('shouldnt call write more than once')
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,6 +17,7 @@ export type SonicBoomOpts = {
     append?: boolean
     mode?: string | number
     mkdir?: boolean
+    contentMode?: 'buffer' | 'utf8'
     retryEAGAIN?: (err: Error, writeBufferLen: number, remainingBufferLen: number) => boolean
 }
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -17,6 +17,7 @@ expectType<SonicBoom>( new SonicBoomCjsImport.default({ fd: 1}));
 expectType<any>( new SonicBoomCjs({ fd: 1}));
 expectType<any>( new SonicBoomCjsNamed({ fd: 1}));
 
+
 expectType<boolean>(sonic.write('hello sonic\n'));
 
 sonic.flush();
@@ -33,5 +34,6 @@ const extraSonic = new SonicBoom({fd: 1, minLength: 0, maxWrite: 16384, sync: tr
 new SonicBoom({fd: 1, minLength: 0, maxWrite: 16384, sync: true, append: true, mode: 0o644, mkdir: true, dest: '/dev/null'});
 new SonicBoom({fd: 1, minLength: 0, maxWrite: 16384, sync: true, append: true, mode: 0o644, mkdir: true, dest: 1});
 new SonicBoom({fd: 1, minLength: 0, maxWrite: 16384, sync: true, fsync: true, append: true, mode: 0o644, mkdir: true});
+new SonicBoom({fd: 1, minLength: 0, maxWrite: 16384, sync: true, fsync: true, append: true, mode: 0o644, mkdir: true, contentMode: 'buffer' });
 
 extraSonic.write('extra sonic\n');


### PR DESCRIPTION
mashed up quick support for .write(chunk: Buffer), works rather well as long as input is a Buffer, in case it is a utf8 string performance degradation is quite bad. See #173 for why it might be needed

if raw buffer is something that is worth exploring further then I'd be happy to put more effort into having fast paths for both types of encoding, probably by preselecting mode of operation at the time of SonicBoom instantiation

```
benchSonic*1000: 2.189s
benchSonicSync*1000: 8.190s
benchSonic4k*1000: 2.147s
benchSonicSync4k*1000: 1.827s
benchCore*1000: 2.561s
benchConsole*1000: 4.835s
benchSonicBuf*1000: 840.388ms
benchSonicSyncBuf*1000: 6.882s
benchSonic4kBuf*1000: 824.605ms
benchSonicSync4kBuf*1000: 481.976ms
benchCoreBuf*1000: 824.466ms
benchSonic*1000: 2.105s
benchSonicSync*1000: 8.275s
benchSonic4k*1000: 2.179s
benchSonicSync4k*1000: 1.811s
benchCore*1000: 2.220s
benchConsole*1000: 5.287s
benchSonicBuf*1000: 856.635ms
benchSonicSyncBuf*1000: 6.852s
benchSonic4kBuf*1000: 849.188ms
benchSonicSync4kBuf*1000: 480.347ms
benchCoreBuf*1000: 802.708ms
```