### PR TITLE
chore: review node versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,8 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22, 24]
         os: [macos-latest, ubuntu-latest, windows-latest]
-        exclude:
-          - node-version: 14
-            os: windows-latest
     steps:
       - name: Check out repo
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR removes node 18 and adds node 22 and 24 to CI