### PR TITLE
chore: move reopen.test.js to node:test

### DIFF
--- a/test/reopen.test.js
+++ b/test/reopen.test.js
@@ -2,44 +2,46 @@
 
 const fs = require('fs')
 const proxyquire = require('proxyquire')
+const { setTimeout: setTimeoutP } = require('node:timers/promises')
 const SonicBoom = require('../')
-const { file, runTestsLegacy: runTests } = require('./helper')
+const { file, runTests, once } = require('./helper')
 
 runTests(buildTests)
 
-function buildTests (test, sync) {
+async function buildTests (test, sync) {
   // Reset the umask for testing
   process.umask(0o000)
 
-  test('reopen', (t) => {
+  test('reopen', (t, end) => {
     t.plan(9)
 
     const dest = file()
     const stream = new SonicBoom({ dest, sync })
 
-    t.ok(stream.write('hello world\n'))
-    t.ok(stream.write('something else\n'))
+    t.assert.ok(stream.write('hello world\n'))
+    t.assert.ok(stream.write('something else\n'))
 
     const after = dest + '-moved'
 
     stream.once('drain', () => {
-      t.pass('drain emitted')
+      t.assert.ok('drain emitted')
 
       fs.renameSync(dest, after)
       stream.reopen()
 
       stream.once('ready', () => {
-        t.pass('ready emitted')
-        t.ok(stream.write('after reopen\n'))
+        t.assert.ok('ready emitted')
+        t.assert.ok(stream.write('after reopen\n'))
 
         stream.once('drain', () => {
           fs.readFile(after, 'utf8', (err, data) => {
-            t.error(err)
-            t.equal(data, 'hello world\nsomething else\n')
+            t.assert.ifError(err)
+            t.assert.strictEqual(data, 'hello world\nsomething else\n')
             fs.readFile(dest, 'utf8', (err, data) => {
-              t.error(err)
-              t.equal(data, 'after reopen\n')
+              t.assert.ifError(err)
+              t.assert.strictEqual(data, 'after reopen\n')
               stream.end()
+              end()
             })
           })
         })
@@ -47,37 +49,38 @@ function buildTests (test, sync) {
     })
   })
 
-  test('reopen with buffer', (t) => {
+  test('reopen with buffer', (t, end) => {
     t.plan(9)
 
     const dest = file()
     const stream = new SonicBoom({ dest, minLength: 4096, sync })
 
-    t.ok(stream.write('hello world\n'))
-    t.ok(stream.write('something else\n'))
+    t.assert.ok(stream.write('hello world\n'))
+    t.assert.ok(stream.write('something else\n'))
 
     const after = dest + '-moved'
 
     stream.once('ready', () => {
-      t.pass('drain emitted')
+      t.assert.ok('drain emitted')
 
       stream.flush()
       fs.renameSync(dest, after)
       stream.reopen()
 
       stream.once('ready', () => {
-        t.pass('ready emitted')
-        t.ok(stream.write('after reopen\n'))
+        t.assert.ok('ready emitted')
+        t.assert.ok(stream.write('after reopen\n'))
         stream.flush()
 
         stream.once('drain', () => {
           fs.readFile(after, 'utf8', (err, data) => {
-            t.error(err)
-            t.equal(data, 'hello world\nsomething else\n')
+            t.assert.ifError(err)
+            t.assert.strictEqual(data, 'hello world\nsomething else\n')
             fs.readFile(dest, 'utf8', (err, data) => {
-              t.error(err)
-              t.equal(data, 'after reopen\n')
+              t.assert.ifError(err)
+              t.assert.strictEqual(data, 'after reopen\n')
               stream.end()
+              end()
             })
           })
         })
@@ -85,52 +88,54 @@ function buildTests (test, sync) {
     })
   })
 
-  test('reopen if not open', (t) => {
+  test('reopen if not open', (t, end) => {
     t.plan(3)
 
     const dest = file()
     const stream = new SonicBoom({ dest, sync })
 
-    t.ok(stream.write('hello world\n'))
-    t.ok(stream.write('something else\n'))
+    t.assert.ok(stream.write('hello world\n'))
+    t.assert.ok(stream.write('something else\n'))
 
     stream.reopen()
 
     stream.end()
     stream.on('close', function () {
-      t.pass('ended')
+      t.assert.ok('ended')
+      end()
     })
   })
 
-  test('reopen with file', (t) => {
+  test('reopen with file', (t, end) => {
     t.plan(10)
 
     const dest = file()
     const stream = new SonicBoom({ dest, minLength: 0, sync })
 
-    t.ok(stream.write('hello world\n'))
-    t.ok(stream.write('something else\n'))
+    t.assert.ok(stream.write('hello world\n'))
+    t.assert.ok(stream.write('something else\n'))
 
     const after = dest + '-new'
 
     stream.once('drain', () => {
-      t.pass('drain emitted')
+      t.assert.ok('drain emitted')
 
       stream.reopen(after)
-      t.equal(stream.file, after)
+      t.assert.strictEqual(stream.file, after)
 
       stream.once('ready', () => {
-        t.pass('ready emitted')
-        t.ok(stream.write('after reopen\n'))
+        t.assert.ok('ready emitted')
+        t.assert.ok(stream.write('after reopen\n'))
 
         stream.once('drain', () => {
           fs.readFile(dest, 'utf8', (err, data) => {
-            t.error(err)
-            t.equal(data, 'hello world\nsomething else\n')
+            t.assert.ifError(err)
+            t.assert.strictEqual(data, 'hello world\nsomething else\n')
             fs.readFile(after, 'utf8', (err, data) => {
-              t.error(err)
-              t.equal(data, 'after reopen\n')
+              t.assert.ifError(err)
+              t.assert.strictEqual(data, 'after reopen\n')
               stream.end()
+              end()
             })
           })
         })
@@ -138,8 +143,8 @@ function buildTests (test, sync) {
     })
   })
 
-  test('reopen throws an error', (t) => {
-    t.plan(sync ? 10 : 9)
+  test('reopen throws an error', async (t) => {
+    t.plan(sync ? 9 : 8)
 
     const fakeFs = Object.create(fs)
     const SonicBoom = proxyquire('../', {
@@ -149,87 +154,92 @@ function buildTests (test, sync) {
     const dest = file()
     const stream = new SonicBoom({ dest, sync })
 
-    t.ok(stream.write('hello world\n'))
-    t.ok(stream.write('something else\n'))
+    t.assert.ok(stream.write('hello world\n'))
+    t.assert.ok(stream.write('something else\n'))
 
     const after = dest + '-moved'
 
-    stream.on('error', () => {
-      t.pass('error emitted')
+    const promise1 = once(stream, 'error', () => {
+      t.assert.ok('error emitted')
     })
 
-    stream.once('drain', () => {
-      t.pass('drain emitted')
+    const promise2 = new Promise((resolve) => {
+      stream.once('drain', async () => {
+        t.assert.ok('drain emitted')
 
-      fs.renameSync(dest, after)
-      if (sync) {
-        fakeFs.openSync = function (file, flags) {
-          t.pass('fake fs.openSync called')
-          throw new Error('open error')
+        fs.renameSync(dest, after)
+        if (sync) {
+          fakeFs.openSync = function (file, flags) {
+            t.assert.ok('fake fs.openSync called')
+            throw new Error('open error')
+          }
+        } else {
+          fakeFs.open = function (file, flags, mode, cb) {
+            t.assert.ok('fake fs.open called')
+            setTimeout(() => cb(new Error('open error')), 0)
+          }
         }
-      } else {
-        fakeFs.open = function (file, flags, mode, cb) {
-          t.pass('fake fs.open called')
-          setTimeout(() => cb(new Error('open error')), 0)
-        }
-      }
 
-      if (sync) {
-        try {
+        if (sync) {
+          try {
+            stream.reopen()
+          } catch (err) {
+            t.assert.ok('reopen throwed')
+          }
+        } else {
           stream.reopen()
-        } catch (err) {
-          t.pass('reopen throwed')
         }
-      } else {
-        stream.reopen()
-      }
 
-      setTimeout(() => {
-        t.ok(stream.write('after reopen\n'))
+        await setTimeoutP(0)
+        t.assert.ok(stream.write('after reopen\n'))
 
         stream.end()
-        stream.on('finish', () => {
-          fs.readFile(after, 'utf8', (err, data) => {
-            t.error(err)
-            t.equal(data, 'hello world\nsomething else\nafter reopen\n')
+        await Promise.all([
+          once(stream, 'finish', () => {
+            const data = fs.readFileSync(after, 'utf8')
+            t.assert.strictEqual(data, 'hello world\nsomething else\nafter reopen\n')
+          }),
+          once(stream, 'close', () => {
+            t.assert.ok('close emitted')
           })
-        })
-        stream.on('close', () => {
-          t.pass('close emitted')
-        })
-      }, 0)
+        ])
+        resolve()
+      })
     })
+
+    await Promise.all([promise1, promise2])
   })
 
-  test('reopen emits drain', (t) => {
+  test('reopen emits drain', (t, end) => {
     t.plan(9)
 
     const dest = file()
     const stream = new SonicBoom({ dest, sync })
 
-    t.ok(stream.write('hello world\n'))
-    t.ok(stream.write('something else\n'))
+    t.assert.ok(stream.write('hello world\n'))
+    t.assert.ok(stream.write('something else\n'))
 
     const after = dest + '-moved'
 
     stream.once('drain', () => {
-      t.pass('drain emitted')
+      t.assert.ok('drain emitted')
 
       fs.renameSync(dest, after)
       stream.reopen()
 
       stream.once('drain', () => {
-        t.pass('drain emitted')
-        t.ok(stream.write('after reopen\n'))
+        t.assert.ok('drain emitted')
+        t.assert.ok(stream.write('after reopen\n'))
 
         stream.once('drain', () => {
           fs.readFile(after, 'utf8', (err, data) => {
-            t.error(err)
-            t.equal(data, 'hello world\nsomething else\n')
+            t.assert.ifError(err)
+            t.assert.strictEqual(data, 'hello world\nsomething else\n')
             fs.readFile(dest, 'utf8', (err, data) => {
-              t.error(err)
-              t.equal(data, 'after reopen\n')
+              t.assert.ifError(err)
+              t.assert.strictEqual(data, 'after reopen\n')
               stream.end()
+              end()
             })
           })
         })


### PR DESCRIPTION
This PR moves `reopen.test.js` to node:test