### PR TITLE
Add maxWriteRetries option to bound unbounded EAGAIN/EBUSY retry loops (fixes #65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ The options are:
     error. `err` is the error that caused this function to be called,
     `writeBufferLen` is the length of the buffer sonic-boom tried to write, and
     `remainingBufferLen` is the length of the remaining buffer sonic-boom didn't try to write.
+* `maxWriteRetries`: the maximum number of *consecutive* EAGAIN/EBUSY retries
+    (across `write`, `writeSync` and `flushSync`) sonic-boom will attempt
+    before giving up and emitting/throwing the error, instead of retrying
+    forever. The counter resets on every successful write. Default: `0`
+    (no limit - preserves the previous unbounded-retry behavior). Set this if
+    the destination can become permanently unwritable (e.g. a reader that
+    stops draining a pipe), to avoid unbounded growth of the internal write
+    buffer while retries are silently attempted forever - see
+    [#65](https://github.com/pinojs/sonic-boom/issues/65).
 
 For `sync:false`  a `SonicBoom` instance will emit the `'ready'` event when a file descriptor is available.
 For `sync:true` this is not relevant because the `'ready'` event will be fired when the `SonicBoom` instance is created, before it can be subscribed to.

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function SonicBoom (opts) {
     return new SonicBoom(opts)
   }
 
-  let { fd, dest, minLength, maxLength, maxWrite, periodicFlush, sync, append = true, mkdir, retryEAGAIN, fsync, contentMode, mode } = opts || {}
+  let { fd, dest, minLength, maxLength, maxWrite, periodicFlush, sync, append = true, mkdir, retryEAGAIN, maxWriteRetries, fsync, contentMode, mode } = opts || {}
 
   fd = fd || dest
 
@@ -126,6 +126,14 @@ function SonicBoom (opts) {
   this.append = append || false
   this.mode = mode
   this.retryEAGAIN = retryEAGAIN || (() => true)
+  // Bounds how many *consecutive* EAGAIN/EBUSY retries (across write,
+  // writeSync and flushSync) are attempted before giving up and surfacing
+  // the error, instead of retrying forever while _bufs keeps growing from
+  // unrelated concurrent write() calls. 0 (default) preserves the existing
+  // unbounded-retry behavior for backward compatibility.
+  // See: https://github.com/pinojs/sonic-boom/issues/65
+  this.maxWriteRetries = maxWriteRetries || 0
+  this._writeRetries = 0
   this.mkdir = mkdir || false
 
   let fsWriteSync
@@ -174,7 +182,13 @@ function SonicBoom (opts) {
 
   this.release = (err, n) => {
     if (err) {
-      if ((err.code === 'EAGAIN' || err.code === 'EBUSY') && this.retryEAGAIN(err, this._writingBuf.length, this._len - this._writingBuf.length)) {
+      const isRetryableErr = (err.code === 'EAGAIN' || err.code === 'EBUSY')
+      if (isRetryableErr) {
+        this._writeRetries++
+      }
+      const retriesExhausted = this.maxWriteRetries > 0 && this._writeRetries > this.maxWriteRetries
+
+      if (isRetryableErr && !retriesExhausted && this.retryEAGAIN(err, this._writingBuf.length, this._len - this._writingBuf.length)) {
         if (this.sync) {
           // This error code should not happen in sync mode, because it is
           // not using the underlining operating system asynchronous functions.
@@ -198,6 +212,15 @@ function SonicBoom (opts) {
       return
     }
 
+    // In sync mode, `release(undefined, 0)` is also used internally as a
+    // "resume after EAGAIN backoff" continuation (see the retry branch
+    // above) rather than always signaling a genuine successful write -
+    // only reset the retry counter once real forward progress (n > 0) is
+    // confirmed, otherwise a stuck destination would never accumulate past
+    // 1 retry and maxWriteRetries could never trigger.
+    if (n > 0) {
+      this._writeRetries = 0
+    }
     this.emit('write', n)
     const releasedBufObj = releaseWritingBuf(this._writingBuf, this._len, n)
     this._len = releasedBufObj.len
@@ -565,6 +588,7 @@ function flushSync () {
       const n = Buffer.isBuffer(buf)
         ? fs.writeSync(this.fd, buf)
         : fs.writeSync(this.fd, buf, 'utf8')
+      this._writeRetries = 0
       const releasedBufObj = releaseWritingBuf(buf, this._len, n)
       buf = releasedBufObj.writingBuf
       this._len = releasedBufObj.len
@@ -573,7 +597,11 @@ function flushSync () {
       }
     } catch (err) {
       const shouldRetry = err.code === 'EAGAIN' || err.code === 'EBUSY'
-      if (shouldRetry && !this.retryEAGAIN(err, buf.length, this._len - buf.length)) {
+      if (shouldRetry) {
+        this._writeRetries++
+      }
+      const retriesExhausted = this.maxWriteRetries > 0 && this._writeRetries > this.maxWriteRetries
+      if (!shouldRetry || retriesExhausted || !this.retryEAGAIN(err, buf.length, this._len - buf.length)) {
         throw err
       }
 
@@ -609,6 +637,7 @@ function flushBufferSync () {
     }
     try {
       const n = fs.writeSync(this.fd, buf)
+      this._writeRetries = 0
       buf = buf.subarray(n)
       this._len = Math.max(this._len - n, 0)
       if (buf.length <= 0) {
@@ -617,7 +646,11 @@ function flushBufferSync () {
       }
     } catch (err) {
       const shouldRetry = err.code === 'EAGAIN' || err.code === 'EBUSY'
-      if (shouldRetry && !this.retryEAGAIN(err, buf.length, this._len - buf.length)) {
+      if (shouldRetry) {
+        this._writeRetries++
+      }
+      const retriesExhausted = this.maxWriteRetries > 0 && this._writeRetries > this.maxWriteRetries
+      if (!shouldRetry || retriesExhausted || !this.retryEAGAIN(err, buf.length, this._len - buf.length)) {
         throw err
       }
 

--- a/test/retry.test.js
+++ b/test/retry.test.js
@@ -419,3 +419,138 @@ test('emit error on async EBUSY', (t, end) => {
     t.assert.ok('close emitted')
   })
 })
+
+test('maxWriteRetries bounds async EAGAIN retries and emits error instead of retrying forever', (t, end) => {
+  t.plan(5)
+
+  const fakeFs = Object.create(fs)
+  let attempts = 0
+  fakeFs.write = function (fd, buf, ...args) {
+    attempts++
+    const err = new Error('EAGAIN')
+    err.code = 'EAGAIN'
+    process.nextTick(args[args.length - 1], err)
+  }
+  const SonicBoom = proxyquire('../', {
+    'node:fs': fakeFs
+  })
+
+  const dest = file()
+  const fd = fs.openSync(dest, 'w')
+  const stream = new SonicBoom({
+    fd,
+    sync: false,
+    minLength: 0,
+    maxWriteRetries: 3,
+    // retryEAGAIN always says "keep going" -- maxWriteRetries must still
+    // cap the actual number of attempts, proving it is an independent bound.
+    retryEAGAIN: () => true
+  })
+
+  stream.on('ready', () => {
+    t.assert.ok('ready emitted')
+  })
+
+  stream.once('error', err => {
+    t.assert.equal(err.code, 'EAGAIN')
+    // 1 initial attempt + 3 retries = 4 total fs.write calls, then give up.
+    t.assert.equal(attempts, 4)
+    t.assert.equal(stream._writing, false)
+    end()
+  })
+
+  t.assert.ok(stream.write('hello world\n'))
+})
+
+test('maxWriteRetries bounds flushSync EAGAIN retries and throws instead of looping forever', (t, end) => {
+  t.plan(2)
+
+  const fakeFs = Object.create(fs)
+  fakeFs.writeSync = function (fd, buf, enc) {
+    const err = new Error('EAGAIN')
+    err.code = 'EAGAIN'
+    throw err
+  }
+  const SonicBoom = proxyquire('../', {
+    'node:fs': fakeFs
+  })
+
+  const dest = file()
+  const fd = fs.openSync(dest, 'w')
+  const stream = new SonicBoom({
+    fd,
+    sync: true,
+    minLength: 0,
+    maxWriteRetries: 3,
+    retryEAGAIN: () => true
+  })
+
+  stream.on('ready', () => {
+    let threw = false
+    try {
+      stream.write('hello world\n')
+    } catch (err) {
+      threw = true
+      t.assert.equal(err.code, 'EAGAIN')
+    }
+    t.assert.ok(threw, 'flushSync threw once retries were exhausted')
+    end()
+  })
+})
+
+test('maxWriteRetries counter resets after a successful write', (t, end) => {
+  t.plan(3)
+
+  // Two separate bursts of 2 EAGAINs each (calls 1-2, then calls 4-5),
+  // separated by one successful write (call 3). Each burst is individually
+  // below maxWriteRetries (3), so this must only succeed if the counter is
+  // reset to 0 by the successful write in between -- if it were cumulative
+  // (2 + 2 = 4 > 3) the stream would incorrectly give up.
+  const fakeFs = Object.create(fs)
+  let call = 0
+  fakeFs.write = function (fd, buf, ...args) {
+    call++
+    if (call % 3 === 0) {
+      return fs.write(fd, buf, ...args)
+    }
+    const err = new Error('EAGAIN')
+    err.code = 'EAGAIN'
+    process.nextTick(args[args.length - 1], err)
+  }
+  const SonicBoom = proxyquire('../', {
+    'node:fs': fakeFs
+  })
+
+  const dest = file()
+  const fd = fs.openSync(dest, 'w')
+  const stream = new SonicBoom({
+    fd,
+    sync: false,
+    minLength: 0,
+    maxWriteRetries: 3,
+    retryEAGAIN: () => true
+  })
+
+  stream.on('error', () => {
+    t.assert.fail('should not give up: each EAGAIN burst is below maxWriteRetries')
+  })
+
+  stream.on('ready', () => {
+    // First burst (calls 1-2 fail, call 3 succeeds) is triggered by this write.
+    t.assert.ok(stream.write('hello world\n'))
+    // Once the first write finishes, queue a second write whose first two
+    // attempts (calls 4-5) also fail with EAGAIN before eventually succeeding.
+    stream.once('drain', () => {
+      stream.write('sonic boom\n')
+      stream.end()
+    })
+  })
+
+  stream.on('finish', () => {
+    fs.readFile(dest, 'utf8', (err, data) => {
+      t.assert.ifError(err)
+      t.assert.equal(data, 'hello world\nsonic boom\n')
+      end()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #65 ("Infinite buffer growth when unable to flush in async mode").

If a destination becomes permanently unwritable (e.g. a pipe reader that
stops draining, or a downstream transport that stops reading), sonic-boom
retries `EAGAIN`/`EBUSY` writes forever by default. The existing
`retryEAGAIN(err, writeBufferLen, remainingBufferLen)` hook lets an
application bail out, but only if it implements its own retry-counting
closure — there's no built-in bound, so the default behavior is: keep
retrying forever while the application keeps calling `write()`, growing
`_bufs` without limit until the process OOMs. A production crash from
exactly this was reported in #65; `retryEAGAIN` was added the same day as a
partial mitigation, but the built-in bound discussed afterwards in that
thread (`maxFlushRetries` / `maxEAGAIN`) was never implemented.

This PR adds an opt-in `maxWriteRetries` option: the number of *consecutive*
`EAGAIN`/`EBUSY` retries (across `write`, `writeSync` and `flushSync`)
allowed before giving up and surfacing the error via the normal `'error'`
event (async) or a thrown exception (sync), instead of retrying forever. The
counter resets whenever a write makes real forward progress.

Default is `0` (no limit) — this is purely additive and preserves current
behavior exactly for existing consumers who don't opt in.

## Implementation note

In sync mode, `release(undefined, 0)` is used internally as a "resume after
backoff" continuation rather than always signaling a genuine successful
write, so the retry counter is only reset when `n > 0` confirms real
progress — resetting unconditionally there would let a stuck sync
destination silently bypass `maxWriteRetries` entirely (I caught this via a
hanging test while developing the fix, see the comment in `release`).

## Test plan
- [x] Added 3 regression tests in `test/retry.test.js`: bounded async retries
      emit `'error'` after the configured limit; bounded `flushSync` retries
      throw after the limit; the retry counter correctly resets between
      independent EAGAIN bursts separated by a successful write (so
      unrelated transient bursts don't cumulatively trip the limit).
- [x] Full existing test suite passes (116/116, no regressions).
- [x] `eslint` and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)